### PR TITLE
Second USENIX Security paper on Anti Fuzzing

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,6 +407,7 @@ https://files.fuzzing-project.org/
 
 [Fuzzification: Anti-Fuzzing Techniques](https://www.usenix.org/conference/usenixsecurity19/presentation/jung)
 
+[AntiFuzz: Impeding Fuzzing Audits of Binary Executables](https://www.usenix.org/conference/usenixsecurity19/presentation/guler)
 
 ## Contributing
 


### PR DESCRIPTION
Added second Anti-Fuzzing Paper in USENIX Security 2019, which was not mentioned earlier. 