### PR TITLE
Update broken FOE links

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,7 +269,7 @@ https://www.corelan.be/index.php/2013/02/26/root-cause-analysis-memory-corruptio
 
 [MozPeach](https://github.com/MozillaSecurity/peach) - A fork of peach 2.7 by Mozilla Security.
 
-[Failure Observation Engine (FOE)](www.cert.org/vulnerability-analysis/tools/foe.cfm) - mutational file-based fuzz testing tool for windows applications.
+[Failure Observation Engine (FOE)](https://vuls.cert.org/confluence/display/tools/CERT+FOE+-+Failure+Observation+Engine) - mutational file-based fuzz testing tool for windows applications.
 
 [rmadair](http://rmadair.github.io/fuzzer/) - mutation based file fuzzer that uses PyDBG to monitor for signals of interest.
 

--- a/README_ch.md
+++ b/README_ch.md
@@ -250,7 +250,7 @@ Awesome Fuzzing Resources
 
 [MozPeach](https://github.com/MozillaSecurity/peac://github.com/MozillaSecurity/peach) - 由 Mozilla Security 开发基于 peach 2.7 版本的分支版本
 
-[Failure Observation Engine (FOE)](http://www.cert.org/vulnerability-analysis/tools/foe.cfm) - 基于畸形文件的 Windows 程序 Fuzzing 工具
+[Failure Observation Engine (FOE)](https://vuls.cert.org/confluence/display/tools/CERT+FOE+-+Failure+Observation+Engine) - 基于畸形文件的 Windows 程序 Fuzzing 工具
 
 [rmadair](http://rmadair.github.io/fuzzer/) - 基于畸形文件的 fuzzer，使用 PyDBG 来监视感兴趣的信号
 


### PR DESCRIPTION
Links for CERT FOE - Failure Observation Engine, were broken(en) and outdated(cn).